### PR TITLE
#4 common_name update

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,16 @@ The CMAQ Exposure API is a RESTful data service implemented in [Swagger](https:/
 Preliminary assumptions
 
 - Python 3 is available on the host
+	- Generally executed using `virtualenv` in the manner:
+
+		```
+		$ virtualenv -p /PATH_TO/python3 venv
+		$ source venv/bin/activate
+		(venv) $ pip install -r requirements.txt
+		(venv) $ python SOMETHING.py [/PATH_TO/SOME_FILE]
+		```
 - Docker and docker-compose are available on the host
+	- Generally executed using a `bash` script that performs `docker` or `docker-compose` calls
 
 **PostgreSQL 9.6 / PostGIS 2.3**:
  

--- a/config/database.ini
+++ b/config/database.ini
@@ -1,5 +1,5 @@
 [postgres]
-host = 152.54.9.79
+host = localhost
 port = 5432
 database = cmaq
 username = datatrans

--- a/data-tools/pre-ingest/update-common-name.py
+++ b/data-tools/pre-ingest/update-common-name.py
@@ -1,0 +1,46 @@
+from configparser import ConfigParser
+import psycopg2
+import sys
+import csv
+
+dbcfg = ConfigParser()
+dbcfg.read('/PATH_TO/cmaq-exposure-api/config/database.ini')
+
+try:
+    file_name = sys.argv[1]
+except Exception as e:
+    print('Usage: python update-cmaq-tables.py FILENAME')
+    print(e)
+    sys.exit(1)
+
+try:
+    conn = psycopg2.connect("dbname='" + dbcfg.get('postgres', 'database') +
+                            "' user='" + dbcfg.get('postgres', 'username') +
+                            "' host='" + dbcfg.get('postgres', 'host') +
+                            "' password='" + dbcfg.get('postgres', 'password') +
+                            "' port='" + dbcfg.get('postgres', 'port') +
+                            "'")
+except psycopg2.OperationalError as e:
+    print(e)
+    sys.exit(1)
+
+with open(file_name) as f:
+    print("UPDATE: exposure_list, SET: common_name")
+    reader = csv.DictReader(f)
+    for row in reader:
+        sql = "SELECT * from exposure_list " \
+              "WHERE type = '" + row['type'] + "';"
+        cur = conn.cursor()
+        cur.execute(sql)
+        res = cur.fetchone()
+        if res is not None:
+            if row['common_name'] and not (res[4] == row['common_name']):
+                sql_update = "UPDATE exposure_list " \
+                             "SET common_name = '" + row['common_name'] + "' " \
+                             "WHERE type = '" + row['type'] + "' ;"
+                print('  --' + sql_update)
+                cur.execute(sql_update)
+                conn.commit()
+        cur.close()
+
+conn.close()

--- a/postgres96/README.md
+++ b/postgres96/README.md
@@ -6,7 +6,7 @@ PostgreSQL 9.6 + PostGIS 2.3
 
 ### Populate Sample Data
 
-See [data-sample/README.md](../data-sample/README.md) for more information.
+See [data-sample/README.md](../data-sample) for more information.
 
 
 ### Start the Database
@@ -53,7 +53,7 @@ Database is running - use your local IP address for connection
 
 Attempts to stop and remove any database related Docker containers. Will also remove all database related Docker images if the `--all` flag is used.
 
-From the `database/` directory:
+From the `postgres96/` directory:
 
 ```
 Usage: ./stop-database.sh [--all]


### PR DESCRIPTION
Create a script to update the `common_name` attribute for CMAQ exposure variables.
- compares values found in the `exposure_list` table against the `exposure_list.csv` file
- use `expsoure_list.csv` file in the repo as the source for updating the deployment